### PR TITLE
used default storage class in pv and pvc, changed access mode to 'readWriteOnce'

### DIFF
--- a/k8s/base/resources/db/pv.yml
+++ b/k8s/base/resources/db/pv.yml
@@ -7,10 +7,9 @@ metadata:
     type: local
     app: postgres
 spec:
-  storageClassName: manual
   capacity:
     storage: 1Gi
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   hostPath:
     path: /mnt/data/postgres

--- a/k8s/base/resources/db/pvc.yml
+++ b/k8s/base/resources/db/pvc.yml
@@ -4,9 +4,8 @@ metadata:
   name: postgres-persistent-volume-claim
   namespace: blog
 spec:
-  storageClassName: do-block-storage
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
•	Removed storageClassName from the PV and PVC: reverted to the cluster’s default StorageClass
•	Changed accessModes in the PV and PVC: switched from ReadWriteMany to ReadWriteOnce