### PR TITLE
changed data directory to be a sub directory of the mount path

### DIFF
--- a/k8s/base/resources/db/statefulset.yml
+++ b/k8s/base/resources/db/statefulset.yml
@@ -31,6 +31,8 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgres-storage


### PR DESCRIPTION
- Redirect Postgres data directory – set PGDATA=/var/lib/postgresql/data/pgdata and use subPath: pgdata on the volume mount so initdb runs in a clean subfolder and bypasses the lost+found directory.